### PR TITLE
icons add for item-fit and icc plots.

### DIFF
--- a/IRT/iCCPlots.js
+++ b/IRT/iCCPlots.js
@@ -305,7 +305,7 @@ if (classOfModel =="Rm" || classOfModel =="dRm")
             ],
             nav: {
                 name: localization.en.navigation,
-                icon: "icon-p_a_given_b",
+                icon: "icon-icc",
                 onclick: `r_before_modal("${config.id}")`
             }
         }

--- a/IRT/itemFit.js
+++ b/IRT/itemFit.js
@@ -95,7 +95,7 @@ local({
             items: [objects.label1.el.content, objects.label1b.el.content, objects.modelselector1.el.content ],
             nav: {
                 name: localization.en.navigation,
-                icon: "icon-p_a_given_b",
+                icon: "icon-item_fit",
                 onclick: `r_before_modal("${config.id}")`
             }
         }


### PR DESCRIPTION
We still need icons for following IRT (ModelEvaluation) dialogs:
- Item and Test Information
- Likelihood Ratios and Plot Betas
- Person Fit
- Plot PI map